### PR TITLE
Financial Information in Product Page

### DIFF
--- a/gateway.php
+++ b/gateway.php
@@ -34,6 +34,12 @@ class WC_Gateway_Mobbex extends WC_Payment_Gateway
         // New Webhook
         $this->use_webhook_api = ($this->get_option('use_webhook_api') === 'yes');
 
+        // Seller CUIT, is going to be use to show financial information in the product page
+        $this->tax_id = $this->get_option('tax_id');
+
+        // Enable or Disable financial information in products
+        $this->financial_info_active = ($this->get_option('financial_info_active') === 'yes');
+
         // Theme
         $this->checkout_title = $this->get_option('checkout_title');
         $this->checkout_logo = $this->get_option('checkout_logo');
@@ -271,6 +277,24 @@ class WC_Gateway_Mobbex extends WC_Payment_Gateway
 
                 'title' => __('Reseller ID', MOBBEX_WC_TEXT_DOMAIN),
                 'description' => __('You can customize your Reseller ID from here. This field is optional and must be used only if was specified by the main seller.', MOBBEX_WC_TEXT_DOMAIN),
+                'type' => 'text',
+                'default' => '',
+
+            ],
+            
+            'financial_info_active' => [
+
+                'title' => __('Financial Information', MOBBEX_WC_TEXT_DOMAIN),
+                'description' => __('Show financial information in all products, Tax_id need to be set.', MOBBEX_WC_TEXT_DOMAIN),
+                'type' => 'checkbox',
+                'default' => '',
+
+            ],
+
+            'tax_id' => [
+
+                'title' => __('Tax ID', MOBBEX_WC_TEXT_DOMAIN),
+                'description' => __('You can customize your Reseller Tax ID from here. This field is optional and must be used only if was specified by the main seller to show financial plans in the product.', MOBBEX_WC_TEXT_DOMAIN),
                 'type' => 'text',
                 'default' => '',
 

--- a/mobbex-for-woocommerce.php
+++ b/mobbex-for-woocommerce.php
@@ -290,12 +290,12 @@ class MobbexGateway
             } 
         </Style>
         <?php
+            global $product;
             //Get the Tax_id(CUIT) from plugin settings
             $mobbexGateway = WC()->payment_gateways->payment_gateways()[MOBBEX_WC_GATEWAY_ID];
             //Set Financial info URL
-            $url_information = "https://mobbex.com/p/sources/widget/arg/".$mobbexGateway->tax_id;
+            $url_information = "https://mobbex.com/p/sources/widget/arg/".$mobbexGateway->tax_id."/?total=".$product->get_price();
             $is_active = $mobbexGateway->financial_info_active;
-            global $product;
             
             // Only for simple product type
             if( ! $product->is_type('simple') ) return;
@@ -303,6 +303,7 @@ class MobbexGateway
             // Trigger/Open The Modal if the checkbox is true in the plugin settings
             if($is_active){
                 echo '<button id="myBtn">Ver Financiación</button>';
+                echo sprintf('<div id="product_total_price" style="margin-bottom:20px;">%s %s</div>',__('Product Total:','woocommerce'),'<span class="price">'.$product->get_price().'</span>');
             }
             
         ?>
@@ -344,6 +345,25 @@ class MobbexGateway
                     modal.style.display = "none";
                 }
             } 
+
+            //acumulate poduct price based in the quantity
+            jQuery(function($){
+                var price = <?php echo $product->get_price(); ?>,
+                taxId = <?php echo $mobbexGateway->tax_id; ?>,
+                currency = '<?php echo get_woocommerce_currency_symbol(); ?>';
+
+                $('[name=quantity]').change(function(){
+                    if (!(this.value < 1)) {
+
+                        var product_total = parseFloat(price * this.value);
+                        $('#product_total_price .price').html( currency + product_total.toFixed(2));
+                        //change the value send to the service
+                        document.getElementById("iframe").src = "https://mobbex.com/p/sources/widget/arg/"+ taxId +'?total='+product_total;
+
+                    }
+                });
+            });
+
         </script>
         <?php
     }

--- a/mobbex-for-woocommerce.php
+++ b/mobbex-for-woocommerce.php
@@ -245,6 +245,8 @@ class MobbexGateway
 
     /**
      * Add new button to show a modal with financial information
+     * only if the checkbox of financial information is checked
+     * @access public
      */
     function additional_button_add_to_cart() {
         ?>
@@ -288,19 +290,28 @@ class MobbexGateway
             } 
         </Style>
         <?php
+            //Get the Tax_id(CUIT) from plugin settings
+            $mobbexGateway = WC()->payment_gateways->payment_gateways()[MOBBEX_WC_GATEWAY_ID];
+            //Set Financial info URL
+            $url_information = "https://mobbex.com/p/sources/widget/arg/".$mobbexGateway->tax_id;
+            $is_active = $mobbexGateway->financial_info_active;
             global $product;
             
             // Only for simple product type
             if( ! $product->is_type('simple') ) return;
-        
-            // Trigger/Open The Modal 
-            echo '<button id="myBtn">Ver Financiación</button>';
+            
+            // Trigger/Open The Modal if the checkbox is true in the plugin settings
+            if($is_active){
+                echo '<button id="myBtn">Ver Financiación</button>';
+            }
+            
         ?>
         <!-- The Modal -->
         <div id="myModal" class="modal">
             <!-- Modal content -->
             <div class="modal-content">
-                <iframe id="iframe"></iframe>
+                <span class="close">&times;</span>
+                <iframe id="iframe" src=<?php echo $url_information ?>></iframe>
             </div>
         </div>
         <script>
@@ -310,11 +321,18 @@ class MobbexGateway
             // Get the button that opens the modal
             var btn = document.getElementById("myBtn");
 
-            // When the user clicks on the button, open the modal
+            // Get the <span> element that closes the modal
+            var span = document.getElementsByClassName("close")[0];
+
+            // When the user clicks on <span> (x), close the modal
+            span.onclick = function() {
+                modal.style.display = "none";
+            }
+
+            // When the user clicks on the button, show/open the modal
             btn.onclick  = function(e) {
                 e.preventDefault();
                 modal.style.display = "block";
-                document.getElementById('iframe').src = "https://mobbex.com/p/sources/widget/arg/20339969532/";
                 window.dispatchEvent(new Event('resize'));
                 document.getElementById('iframe').style.height = "100%"; 
                 return false;

--- a/mobbex-for-woocommerce.php
+++ b/mobbex-for-woocommerce.php
@@ -53,6 +53,9 @@ class MobbexGateway
         MobbexGateway::load_gateway();
         MobbexGateway::add_gateway();
 
+        //Add a new button after the "add to cart" button
+        add_action( 'woocommerce_after_add_to_cart_button', [$this,'additional_button_add_to_cart'], 20 );
+
         // Add some useful things
         add_filter('plugin_action_links_' . plugin_basename(__FILE__), [$this, 'add_action_links']);
         add_filter('plugin_row_meta', [$this, 'plugin_row_meta'], 10, 2);
@@ -237,6 +240,94 @@ class MobbexGateway
             echo ob_get_clean();
         });
 
+    }
+
+
+    /**
+     * Add new button to show a modal with financial information
+     */
+    function additional_button_add_to_cart() {
+        ?>
+        <Style>
+            /* The Modal (background) */
+            .modal {
+                display: none; /* Hidden by default */
+                position: fixed; /* Stay in place */
+                z-index: 1; /* Sit on top */
+                left: 0;
+                top: 0;
+                width: 100%; /* Full width */
+                height: 100%; /* Full height */
+                overflow: auto; /* Enable scroll if needed */
+                background-color: rgb(0,0,0); /* Fallback color */
+                background-color: rgba(0,0,0,0.4); /* Black w/ opacity */
+            }
+            
+            /* Modal Content/Box */
+            .modal-content {
+                background-color: #fefefe;
+                margin: 10% auto auto; /* 15% from the top and centered */
+                padding: 20px;
+                border: 1px solid #888;
+                width: 60%; /* Could be more or less, depending on screen size */
+                height: 100%; /* Full height */
+            }
+            /* The Close Button */
+            .close {
+                color: #aaa;
+                float: right;
+                font-size: 28px;
+                font-weight: bold;
+            }
+            
+            .close:hover,
+            .close:focus {
+                color: black;
+                text-decoration: none;
+                cursor: pointer;
+            } 
+        </Style>
+        <?php
+            global $product;
+            
+            // Only for simple product type
+            if( ! $product->is_type('simple') ) return;
+        
+            // Trigger/Open The Modal 
+            echo '<button id="myBtn">Ver Financiación</button>';
+        ?>
+        <!-- The Modal -->
+        <div id="myModal" class="modal">
+            <!-- Modal content -->
+            <div class="modal-content">
+                <iframe id="iframe"></iframe>
+            </div>
+        </div>
+        <script>
+            // Get the modal
+            var modal = document.getElementById("myModal");
+
+            // Get the button that opens the modal
+            var btn = document.getElementById("myBtn");
+
+            // When the user clicks on the button, open the modal
+            btn.onclick  = function(e) {
+                e.preventDefault();
+                modal.style.display = "block";
+                document.getElementById('iframe').src = "https://mobbex.com/p/sources/widget/arg/20339969532/";
+                window.dispatchEvent(new Event('resize'));
+                document.getElementById('iframe').style.height = "100%"; 
+                return false;
+            }
+
+            // When the user clicks anywhere outside of the modal, close it
+            window.onclick = function(event) {
+                if (event.target == modal) {
+                    modal.style.display = "none";
+                }
+            } 
+        </script>
+        <?php
     }
 
     public function mobbex_product_settings_tabs($tabs)


### PR DESCRIPTION
# Description

Add a button to show the financial information of products, and the option to establish the seller tax_id.


## Tasks

- [x] Add button "View Financial Information" in product page
- [x] Add modal with the financial/payment information
- [x] Add and save tax_id in admin page
- [x] Add and save Financial information checkbox to enable the button


# Tested

The plugin was tested in the following versions of WordPress
- [x] 5.1