### PR TITLE
Fix PHP 8 warning when REQUEST_URI is null

### DIFF
--- a/mobbex-for-woocommerce.php
+++ b/mobbex-for-woocommerce.php
@@ -196,7 +196,7 @@ class MobbexGateway
     public static function check_upgrades()
     {
         try {
-            $request_uri = filter_input(INPUT_SERVER, 'REQUEST_URI');
+            $request_uri = filter_input(INPUT_SERVER, 'REQUEST_URI') ?? '';
             // Checks current version updated and if it's not installing route
             if (get_option('woocommerce-mobbex-version') == MOBBEX_VERSION && !str_contains($request_uri, 'plugin-install'))
                 return;


### PR DESCRIPTION
Fixes php 8.1+ deprecation warning "`PHP Deprecated:  str_contains(): Passing null to parameter #1 ($haystack) of type string is deprecated`"